### PR TITLE
Fixed Testnet WBNB Address

### DIFF
--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -66,7 +66,7 @@ export const WETH = {
   ),
   [ChainId.BSCTESTNET]: new Token(
     ChainId.BSCTESTNET,
-    '0xaE8E19eFB41e7b96815649A6a60785e1fbA84C1e',
+    '0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd',
     18,
     'WBNB',
     'Wrapped BNB'


### PR DESCRIPTION
Old address doesn't let test swapETH router methods due to unavailability of receive function to allow Test BNB